### PR TITLE
PLA-2150/PLA-2162/fix-nginx-config-and-query-handler

### DIFF
--- a/nginx-http-dmp.conf
+++ b/nginx-http-dmp.conf
@@ -3,7 +3,7 @@ server {
   listen [::]:80 default_server;
 
   location /query {
-    proxy_pass http://influxdb.1plusx.io:8086;
+    proxy_pass http://influxdb-euc1.1plusx.io:8086;
   }
 
   location / {

--- a/relay/http.go
+++ b/relay/http.go
@@ -73,7 +73,7 @@ var (
 		"/admin":             (*HTTP).handleAdmin,
 		"/admin/flush":       (*HTTP).handleFlush,
 		"/health":            (*HTTP).handleHealth,
-		"/query":             (*HTTP).handleQuery,
+		//"/query":             (*HTTP).handleQuery,
 	}
 
 	middlewares = []relayMiddleware{

--- a/relay/http_handlers.go
+++ b/relay/http_handlers.go
@@ -128,9 +128,9 @@ func (h *HTTP) handleHealth(w http.ResponseWriter, _ *http.Request, _ time.Time)
 	return
 }
 
-func (h *HTTP) handleQuery(w http.ResponseWriter, r *http.Request, _ time.Time) {
-	http.Redirect(w, r, "influxdb.1plusx.io:8086", 301)
-}
+//func (h *HTTP) handleQuery(w http.ResponseWriter, r *http.Request, _ time.Time) {
+//	http.Redirect(w, r, "influxdb.1plusx.io:8086", 301)
+//}
 
 func (h *HTTP) handleAdmin(w http.ResponseWriter, r *http.Request, _ time.Time) {
 	// Client to perform the raw queries


### PR DESCRIPTION
- Change nginx http config proxy pass to point to influxdb-euc1.1plusx.io instead of influxdb.1plusx.io which creates a circular dependency after the later was changed into and alias for influxbd-relay-nlb.1plusx.io which points the traffic back to the relay and nginx
- Revert commit 841ead1 that adds a /query endpoint httpd handler to redirect traffic since it didn't seem to work
